### PR TITLE
Fixes GHA coordinates provided at examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: ''
 
-      - uses: guardsquare/appsweep-action@master
+      - uses: guardsquare/appsweep-action@main
         env:
           APPSWEEP_API_KEY: ${{ secrets.APPSWEEP_API_KEY }}
           INPUT_FILE: InsecureBankv2.apk
@@ -65,7 +65,7 @@ jobs:
         with:
           repository: ''
 
-      - uses: guardsquare/appsweep-action@master
+      - uses: guardsquare/appsweep-action@main
         env:
           APPSWEEP_API_KEY: ${{ secrets.APPSWEEP_API_KEY }}
           INPUT_FILE: InsecureBankv2.apk


### PR DESCRIPTION
After trying this GHA in one of my projects, I caught [this error](https://github.com/dotanuki-labs/norris/runs/3915408792?check_suite_focus=true), since the examples point to the another convention name instead of the one used by the default branch in this repository.

This PR fixes that. Successful Workflow run [here](https://github.com/dotanuki-labs/norris/runs/3915488452?check_suite_focus=true)